### PR TITLE
Switched date_format, started getting "TypeError: must be str, not datetime.datetime"

### DIFF
--- a/blogofile_blog/__init__.py
+++ b/blogofile_blog/__init__.py
@@ -6,7 +6,6 @@ import blogofile
 import blogofile.plugin
 from blogofile.cache import bf, HierarchicalCache as HC
 
-
 from . import commands
 
 ## Configure the plugin meta information:
@@ -110,6 +109,7 @@ config = HC(
     template_path = None,
     #Posts
     post = HC(
+        source_dir = "_posts",
         date_format = "%Y/%m/%d %H:%M:%S",
         encoding = "utf-8",
         #What files in _posts directory should we consider posts?

--- a/blogofile_blog/site_src/_controllers/blog/__init__.py
+++ b/blogofile_blog/site_src/_controllers/blog/__init__.py
@@ -51,7 +51,7 @@ def run():
     from . import feed
     from . import permapage
     #Parse the posts
-    blog.posts = post.parse_posts("_posts")
+    blog.posts = post.parse_posts(blog.post.source_dir)
     if blog.post.post_process:
         #The user may define their own callback to process posts after
         #they have been parsed but before we've done any actual work.

--- a/blogofile_blog/site_src/_controllers/blog/archives.py
+++ b/blogofile_blog/site_src/_controllers/blog/archives.py
@@ -13,7 +13,6 @@ from . import chronological
 
 from . import blog, tools
 
-
 def run():
     write_monthly_archives()
     write_index()

--- a/blogofile_blog/site_src/_controllers/blog/post.py
+++ b/blogofile_blog/site_src/_controllers/blog/post.py
@@ -391,7 +391,7 @@ def parse_posts(directory):
     Returns a list of the posts sorted in reverse by date."""
     posts = []
     post_filename_re = re.compile(config.file_regex)
-    if not os.path.isdir("_posts"):
+    if not os.path.isdir(directory):
         logger.warn("This site has no _posts directory.")
         return []
     post_paths = [f for f in bf.util.recursive_file_list(
@@ -452,9 +452,9 @@ categories: {categories}
 guid: {uuid}
 ---
 """.format(**params)
-    if not os.path.isdir("_posts"):
-        util.mkdir("_posts")
-    post_filename = os.path.join("_posts",create_post_filename(
+    if not os.path.isdir(config.source_dir):
+        util.mkdir(config.source_dir)
+    post_filename = os.path.join(config.source_dir,create_post_filename(
                 ":year-:month-:day - :title.markdown", title, date))
     if os.path.exists(post_filename):
         logger.error("A file already exists called {0}, I won't overwrite it.".format(post_filename))


### PR DESCRIPTION
If config.date_format is %Y-%m-%d %H:%M:%S, then the date will have already been converted to a datetime object by the YAML parser.
