### PR TITLE
Fix links in RSS feeds on a subdir

### DIFF
--- a/blogofile_blog/site_src/_controllers/blog/__init__.py
+++ b/blogofile_blog/site_src/_controllers/blog/__init__.py
@@ -37,7 +37,7 @@ def iter_posts_published(limit=None):
     return iter_posts(is_publishable,limit)
 
 def init():
-    config["url"] = urllib.parse.urljoin(bf.config.site.url, config["path"])
+    config["url"] = bf.config.site.url + config["path"]
     if config.template_path:
         #Add the user's custom template path first
         tools.add_template_dir(config.template_path)


### PR DESCRIPTION
I've just discovered that some of the links are wrong in my RSS feeds.

My blog is at a subdirectory /subdir but the generated urls have that
/subdir missing.

site.url = "http://www.example.com/subdir"
blog.path = "/blog"

The feeds use bf.config.blog.url.

```
atom.mako:13:  <link rel="alternate" type="text/html" href="${bf.config.blog.url}" />
atom.mako:14:  <id>${bf.config.blog.url}/feed/atom/</id>
atom.mako:15:  <link rel="self" type="application/atom+xml" href="${bf.config.blog.url}/feed/atom/" />
atom.mako:20:      <uri>${bf.config.blog.url}</uri>
atom.mako:28:    <category scheme="${bf.config.blog.url}" term="${category}" />
rss.mako:11:    <link>${bf.config.blog.url}</link>
```

The problem is urllib.parse.urljoin - it isn't quite working in the
expected way - the leading "/" on the "/blog" is causing it to treat
"/blog" as an absolute path.

```
>>> import urllib.parse
>>> urllib.parse.urljoin("http://www.example.com/subdir", "/blog")
'http://www.example.com/blog'
>>>
```

This fixes the problem, but there may be a neater way...
