### PR TITLE
HTML5 compliance

### DIFF
--- a/blogofile_blog/site_src/_templates/blog/post.mako
+++ b/blogofile_blog/site_src/_templates/blog/post.mako
@@ -13,14 +13,14 @@
 <article>
   <div class="blog_post">
     <header>
-      <a name="${post.slug}"></a>
+      <div id="${post.slug}"></div>
       <h2 class="blog_post_title"><a href="${post.permapath()}" rel="bookmark" title="Permanent Link to ${post.title}">${post.title}</a></h2>
-      <small><span class="blog_post_date">${post.date.strftime("%B %d, %Y at %I:%M %p")}</span> | categories: 
+      <p><small><span class="blog_post_date">${post.date.strftime("%B %d, %Y at %I:%M %p")}</span> | categories: 
         <span class="blog_post_categories">${", ".join(category_links)}</span>
         % if bf.config.blog.disqus.enabled:
         | <a href="${post.permalink}#disqus_thread">View Comments</a>
         % endif
-      </small><p/>
+      </small></p>
     </header>
     <div class="post_prose">
       ${self.post_prose(post)}


### PR DESCRIPTION
this shuts the w3c validator up when checking for html5 validity:

removes the obsolete 'a name=...' and replaces it by 'div id=...'
as well as replacing self-contained `<p/>` by `<p></p>`
