### PR TITLE
Fix source of ResourceWarning exceptions.

### DIFF
--- a/blogofile_blog/site_src/_controllers/blog/post.py
+++ b/blogofile_blog/site_src/_controllers/blog/post.py
@@ -392,7 +392,8 @@ def parse_posts(directory):
         #It refuses to open files without replacing newlines with CR+LF
         #reverting to regular open and decode:
         try:
-            src = open(post_path, "r").read()
+            with open(post_path, "r") as src_file:
+                src = src_file.read()
         except:
             logger.exception("Error reading post: {0}".format(post_path))
             raise


### PR DESCRIPTION
A ResourceWarning exception show up when running `blogofile build` under Python 3.2 with PYTHONWARNINGS=default. This fixes it by putting the offending open statement in a with statement context manager.
