### PR TITLE
Use config.post.default_markup to specify extension for created post files.

### DIFF
--- a/blogofile_blog/site_src/_controllers/blog/post.py
+++ b/blogofile_blog/site_src/_controllers/blog/post.py
@@ -416,7 +416,8 @@ def create_post_filename(spec, title, date):
     filename = re.sub(":second", date.strftime("%S"), filename)
     return filename
 
-def create_post_template(title,**params):
+
+def create_post_template(title, **params):
     params['title'] = title
     if "date" in params:
         date = params['date']
@@ -442,11 +443,12 @@ guid: {uuid}
 """.format(**params)
     if not os.path.isdir(config.source_dir):
         util.mkdir(config.source_dir)
-    post_filename = os.path.join(config.source_dir,create_post_filename(
-                ":year-:month-:day - :title.markdown", title, date))
+    markup = blog_config.post.default_markup or "markdown"
+    post_filename = os.path.join(config.source_dir, create_post_filename(
+        ":year-:month-:day - :title.{0}".format(markup), title, date))
     if os.path.exists(post_filename):
-        logger.error("A file already exists called {0}, I won't overwrite it.".format(post_filename))
+        logger.error("A file already exists called {0}, I won't overwrite it."
+                     .format(post_filename))
         return
-    with open(post_filename,"w") as f:
+    with open(post_filename, "w") as f:
         f.write(template)
-        


### PR DESCRIPTION
The `blogofile blog post create` command is hardcoded to create a file with the extension `.markdown`. This change uses a new config option, `blog.post.default_markup` to permit an alternative to be specified. I use RST markup, so have set `blog.post.default_markup = 'rst'` in my `_config.py` file. If `blog.post.default_markup` is not set the default remains `.markdown`.

This pull requests also contains a few compulsive whitespace and PEP8 cleanup changes. Apologies for mixing them with feature changes.
