### PR TITLE
on YAML error display the original error message

### DIFF
--- a/blogofile_blog/site_src/_controllers/blog/post.py
+++ b/blogofile_blog/site_src/_controllers/blog/post.py
@@ -195,7 +195,7 @@ class Post(object):
             if getattr(e, 'context_mark', None):
                 linenum = 1 + e.context_mark.line
             raise PostParseException(
-                "Post has bad YAML section: {0}:{1}".format(
+                "Post has bad YAML section: {0}:{1} {2}".format(
                     self.filename, linenum, str(e)))
         if not isinstance(y, dict):
             raise PostParseException(


### PR DESCRIPTION
while the exception was present in the format arguments, 
it didn't have a placeholder in the actual error message
string that was being formatted. 

Note: str.format and the old style % have different behavior (python 2.6/2.7):

``` python
>>> '%s %s' % ('sdf', 'qwerty', 'this is the omitted third argument')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not all arguments converted during string formatting
>>> '{0} {1}'.format('sdf', 'qwerty', 'this is the omitted third argument')
'sdf qwerty'
```
