### PR TITLE
Excerpts

### DIFF
--- a/blogofile_blog/__init__.py
+++ b/blogofile_blog/__init__.py
@@ -129,12 +129,12 @@ config = HC(
         # If a post does not specify a filter chain, use the
         # following defaults based on the post file extension:
         default_filters={
-           "markdown": "syntax_highlight, markdown",
-           "md": "syntax_highlight, markdown",
-           "textile": "syntax_highlight, textile",
-           "org": "syntax_highlight, org",
-           "rst": "syntax_highlight, rst",
-           "html": "syntax_highlight"
+           "markdown": "latex, syntax_highlight, markdown",
+           "md"      : "latex, syntax_highlight, markdown",
+           "textile" : "latex, syntax_highlight, textile",
+           "org"     : "latex, syntax_highlight, org",
+           "rst"     : "latex, syntax_highlight, rst",
+           "html"    : "latex, syntax_highlight"
            },
         #An optional callback to run after all the posts are parsed
         #but before anything else is done with them.

--- a/blogofile_blog/site_src/_controllers/blog/post.py
+++ b/blogofile_blog/site_src/_controllers/blog/post.py
@@ -158,13 +158,21 @@ class Post(object):
         try:
             import lxml.html
         except ImportError:
-            print("\nlxml is required in order to create post excerpts.")
-            print("See http://lxml.de/installation.html for installation "
+            try:
+                import bs4
+            except ImportError:
+                print("\nlxml or bs4 is required in order to create post excerpts.")
+                print("See http://lxml.de/installation.html for installation "
                   "instructions.")
             print("You can also turn off post excerpts in your _config.py:")
             print("\n    plugins.blog.post_excerpts = False\n")
             sys.exit(1)
-        post_text = lxml.html.fromstring(self.content).text_content()
+
+        if lxml.html:
+            post_text = lxml.html.fromstring(self.content).text_content()
+        elif bs4:
+            soup = bs4.BeautifulSoup(self.content)
+            post_text = soup.text
         post_words = post_text.split(None, num_words)
         return " ".join(post_words[:num_words])
 
@@ -195,7 +203,7 @@ class Post(object):
             if getattr(e, 'context_mark', None):
                 linenum = 1 + e.context_mark.line
             raise PostParseException(
-                "Post has bad YAML section: {0}:{1} {2}".format(
+                "Post has bad YAML section: {0}:{1}".format(
                     self.filename, linenum, str(e)))
         if not isinstance(y, dict):
             raise PostParseException(

--- a/blogofile_blog/site_src/_controllers/blog/post.py
+++ b/blogofile_blog/site_src/_controllers/blog/post.py
@@ -159,20 +159,20 @@ class Post(object):
             import lxml.html
         except ImportError:
             try:
-                import bs4
+                import bs4           
             except ImportError:
                 print("\nlxml or bs4 is required in order to create post excerpts.")
-                print("See http://lxml.de/installation.html for installation "
-                  "instructions.")
-            print("You can also turn off post excerpts in your _config.py:")
-            print("\n    plugins.blog.post_excerpts = False\n")
-            sys.exit(1)
-
-        if lxml.html:
+                print("See http://lxml.de/installation.html for lxml installation instructions.")
+                print("See http://www.crummy.com/software/BeautifulSoup/#Download for bs4 installation instructions.")
+                print("You can also turn off post excerpts in your _config.py:")
+                print("\n    plugins.blog.post_excerpts = False\n")
+                sys.exit(1)
+            else:
+                soup = bs4.BeautifulSoup(self.content)
+                post_text = soup.text 
+        else:
             post_text = lxml.html.fromstring(self.content).text_content()
-        elif bs4:
-            soup = bs4.BeautifulSoup(self.content)
-            post_text = soup.text
+
         post_words = post_text.split(None, num_words)
         return " ".join(post_words[:num_words])
 

--- a/blogofile_blog/site_src/_filters/latex.py
+++ b/blogofile_blog/site_src/_filters/latex.py
@@ -101,8 +101,10 @@ def render_latex_blocks(src, cache_dir="_tmp", site_images_dir="images"):
         img_substitutions[m.group()] = "<img src=\"%s\">" % \
             (bf.util.site_path_helper(site_images_dir,fn))
     #Make the <img> tag replacements in a single pass
-    p = re.compile('|'.join(map(re.escape, img_substitutions)))
-    return p.sub(lambda x: img_substitutions[x.group(0)], src)
-    
+    if img_substitutions:
+        p = re.compile('|'.join(map(re.escape, img_substitutions)))
+        return p.sub(lambda x: img_substitutions[x.group(0)], src)
+    return src
+
 def run(src):
     return render_latex_blocks(src)

--- a/blogofile_blog/site_src/_filters/latex.py
+++ b/blogofile_blog/site_src/_filters/latex.py
@@ -1,0 +1,108 @@
+"""
+Render TeX blocks to png
+ 
+This is a Blogofile filter. Place it in your _filters directory.
+"""
+import tempfile
+import subprocess
+import shutil
+import shlex
+import os
+import re
+import hashlib
+import blogofile_bf as bf
+ 
+tex_template = r"""
+\documentclass{article}
+\usepackage{amsmath}
+\usepackage{amsthm}
+\usepackage{amssymb}
+\usepackage{bm}
+\newcommand{\mx}[1]{\mathbf{\bm{#1}}}
+\newcommand{\vc}[1]{\mathbf{\bm{#1}}}
+\newcommand{\T}{\text{T}}
+\pagestyle{empty}
+\begin{document}
+%s
+\newpage 
+\end{document}
+"""
+ 
+latex_block_re = re.compile(r"\s\$\$latex\s(.*?)\s\$", re.DOTALL)
+ 
+def render_tex_math_expr_to_png(math_block, png_location):
+    """Wrap a mathematical TeX expression in $ symbols and render"""
+    render_tex_to_png("$%s$" % math_block, png_location)
+ 
+def render_tex_to_png(latex_block, png_location):
+    """Render a TeX formatted string to an image file
+ 
+    Depends on 'latex' and 'dvipng' binaries on the system path
+    """
+ 
+    #Create a temporary directory and go into it
+    tmp_dir = tempfile.mkdtemp()
+    previous_dir = os.getcwd()
+    os.chdir(tmp_dir)
+ 
+    tex_f = open(os.path.join(tmp_dir,"source.tex"),"w")
+    tex_f.write((tex_template % latex_block))
+    tex_f.close()
+ 
+    try:
+        #Generate the .dvi
+        p = subprocess.Popen(shlex.split(
+                'latex -interaction=nonstopmode source.tex'),
+                             stdout=subprocess.PIPE)
+        p.wait()
+        #Generate the .ps
+        p = subprocess.Popen(shlex.split('dvips source.dvi'),
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        p.wait()
+        #Generate the .png
+        p = subprocess.Popen(shlex.split(
+                'convert -density 120 -trim -transparent'
+                ' "#FFFFFF" source.ps rendered.png'),stdout=subprocess.PIPE)
+        p.wait()
+        #Copy the .png to the png_location
+        os.chdir(previous_dir)
+        shutil.copyfile(os.path.join(tmp_dir,"rendered.png"),png_location)
+    finally:
+        #Go back to the original directory and clean up the temp files
+        os.chdir(previous_dir)
+        shutil.rmtree(tmp_dir)
+        
+def render_latex_blocks(src, cache_dir="_tmp", site_images_dir="images"):
+    """Render a document with LaTeX blocks
+ 
+    1) Extract all the $$latex blocks
+    2) Render each TeX block to an image to the cache
+    3) Copy the (pre)rendered image from the cache to the _site dir
+    4) Replace the $$latex blocks with <img> tags
+    """
+    img_substitutions = {}
+    for m in latex_block_re.finditer(src):
+        tex_expr = m.groups()[0]
+        fn = hashlib.md5(tex_expr).hexdigest()+".png"
+        png_cached = os.path.join(cache_dir,fn)
+        site_png_dir = bf.util.path_join("_site",bf.util.fs_site_path_helper(
+                site_images_dir))
+        site_png = bf.util.path_join(site_png_dir,fn)
+        #only render the image if the image is not already cached
+        if(not os.path.isfile(png_cached)):
+            bf.util.mkdir(cache_dir)
+            bf.filter.logger.info("Rendering LaTeX: "+tex_expr)
+            render_tex_math_expr_to_png(tex_expr,png_cached)
+        #copy the rendered image to the site dir
+        bf.util.mkdir(site_png_dir)
+        shutil.copyfile(png_cached,site_png)
+        #record the $$latex block and it's replacement <img> tag
+        img_substitutions[m.group()] = "<img src=\"%s\">" % \
+            (bf.util.site_path_helper(site_images_dir,fn))
+    #Make the <img> tag replacements in a single pass
+    p = re.compile('|'.join(map(re.escape, img_substitutions)))
+    return p.sub(lambda x: img_substitutions[x.group(0)], src)
+    
+def run(src):
+    return render_latex_blocks(src)

--- a/blogofile_blog/site_src/_posts/latex.markdown
+++ b/blogofile_blog/site_src/_posts/latex.markdown
@@ -1,0 +1,21 @@
+---
+categories: Category 1, Category 2
+date: 2009/07/24 16:20:00
+title: Sample LaTeX post
+filter: latex, markdown
+tags: test, blogofile, cool-stuff
+author: Ryan
+---
+This is a sample post with TeX blocks.
+
+This is a TeX block:
+$$latex
+y = \int_0^\infty \gamma^2 \cos(x) dx $ this is after the block.
+
+This is an inline Tex block: $$latex \cos(x) $ and this is after.
+
+This is two seperate inline Tex blocks: $$latex \sin(x) $ and then $$latex \tan(x) $ and this is after.
+
+This is a mistyped TeX block because I didn't terminate it properly. $$latex \tan(x)$ and this text is rendered too because I didn't put a space before the dollar sign $
+
+This is a broken TeX block because I didn't put a space before it$$latex \tan(x) $

--- a/blogofile_blog/site_src/_templates/blog/chronological.mako
+++ b/blogofile_blog/site_src/_templates/blog/chronological.mako
@@ -1,9 +1,9 @@
 <%inherit file="bf_base_template" />
 % for post in posts:
-  <%include file="post.mako" args="post=post" />
-% if bf.config.blog.disqus.enabled:
-  <div class="after_post"><a href="${post.permalink}#disqus_thread">Read and Post Comments</a></div>
-% endif
+  <%include file="post.mako" args="post=post, excerpted=bf.config.blog.post_excerpts.enabled" />
+  % if bf.config.blog.disqus.enabled:
+    <div class="after_post"><a href="${post.permalink}#disqus_thread">Read and Post Comments</a></div>
+  % endif
   <hr class="interblog" />
 % endfor
 % if prev_link:

--- a/blogofile_blog/site_src/_templates/blog/post.mako
+++ b/blogofile_blog/site_src/_templates/blog/post.mako
@@ -1,4 +1,4 @@
-<%page args="post"/>
+<%page args="post, excerpted=False"/>
 
 <% 
    category_links = []
@@ -23,11 +23,15 @@
       </small></p>
     </header>
     <div class="post_prose">
-      ${self.post_prose(post)}
+      ${self.post_prose(post, excerpted)}
     </div>
   </div>
 </article>
 
-<%def name="post_prose(post)">
-${post.content}
+<%def name="post_prose(post, excerpted)">
+  % if excerpted:
+    ${post.excerpt}
+  % else:
+    ${post.content}
+  % endif
 </%def>

--- a/blogofile_blog/site_src/_templates/blog/post_excerpt.mako
+++ b/blogofile_blog/site_src/_templates/blog/post_excerpt.mako
@@ -1,4 +1,0 @@
-<%inherit file="post.mako" />
-<%def name="post_prose(post)">
-  ${post.excerpt}
-</%def>

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,11 @@ dependencies = [
 if PY26:
     dependencies.append('argparse')
 
+try:
+    import lxml
+except ImportError:
+    dependencies.append('beautifulsoup4')
+
 
 def find_package_data(module, path):
     """Find all data files to include in the package.


### PR DESCRIPTION
So far, using the excerpts feature in the blog was not straightforward, and required  the user to customize the templates. See [here](http://www.blogofile.com/demo/post_excerpts.html) for explanation.

This patch handles the following two issues:
1. The chronological template will automatically use the correct form (excerpt/content) depending on the value of "blog.post_excerpts.enabled" in _config.py.
2. Based on pull #26 of nryoung, blogofile will fall through to bf4 if lxml is not installed. A discussion [here](https://groups.google.com/forum/?fromgroups#!topic/blogofile-discuss/7Y7eXWOH29o) have more information on the reason for this.

I am aware that you are travelling, so do not worry about reviewing this pull request fast.
