### PR TITLE
Load disqus with a protocol-relative URL

### DIFF
--- a/blogofile_blog/site_src/_templates/blog/permapage.mako
+++ b/blogofile_blog/site_src/_templates/blog/permapage.mako
@@ -5,6 +5,6 @@
 <script type="text/javascript">
   var disqus_url = "${post.permalink}";
 </script>
-<script type="text/javascript" src="http://disqus.com/forums/${bf.config.blog.disqus.name}/embed.js"></script>
+<script type="text/javascript" src="//disqus.com/forums/${bf.config.blog.disqus.name}/embed.js"></script>
 <noscript><a href="http://${bf.config.blog.disqus.name}.disqus.com/?url=ref">View the discussion thread.</a></noscript><a href="http://disqus.com" class="dsq-brlink">blog comments powered by <span class="logo-disqus">Disqus</span></a>
 % endif

--- a/blogofile_blog/site_src/_templates/body_scripts.mako
+++ b/blogofile_blog/site_src/_templates/body_scripts.mako
@@ -24,7 +24,7 @@
               query += 'url' + i + '=' + encodeURIComponent(links[i].href) + '&';
           }
       }
-      document.write('<script charset="utf-8" type="text/javascript" src="http://disqus.com/forums/${bf.config.blog.disqus.name}/get_num_replies.js' + query + '"></' + 'script>');
+      document.write('<script charset="utf-8" type="text/javascript" src="//disqus.com/forums/${bf.config.blog.disqus.name}/get_num_replies.js' + query + '"></' + 'script>');
   })();
   </script>
   % endif


### PR DESCRIPTION
This allows a blogofile site served via https to use disqus commenting without triggering mixed content warnings.

Reference: http://help.disqus.com/customer/portal/articles/542119
