### PR TITLE
Fix to allow customization of blog.filters.syntax_highlight.css_dir

### DIFF
--- a/blogofile_blog/site_src/_filters/syntax_highlight.py
+++ b/blogofile_blog/site_src/_filters/syntax_highlight.py
@@ -127,7 +127,9 @@ def parse_args(args):
 
 
 def write_pygments_css(style, formatter,
-        location=config.css_dir):
+        location=None):
+    if location is None:
+        location = config.css_dir
     path = bf.util.path_join("_site", bf.util.fs_site_path_helper(location))
     bf.util.mkdir(path)
     css_file = "pygments_{0}.css".format(style)


### PR DESCRIPTION
It is currently not possible to configure the pygments css files generated by the syntax highlight filter to be written to any directory other than '/css'.

This is because the attribute lookup for `config.css_dir`, the default value for the `location` argument of `write_pygments_css()`, is performed at compile-time, before the user’s `_config.py` has been read.

This fixes that.
