### PR TITLE
Move package metadata into setup.py

### DIFF
--- a/blogofile_blog/__init__.py
+++ b/blogofile_blog/__init__.py
@@ -5,6 +5,7 @@ try:
     from urllib.parse import urlparse   # For Python 2
 except ImportError:
     from urlparse import urlparse       # For Python 2; flake8 ignore # NOQA
+import pkginfo
 import blogofile
 import blogofile.plugin
 from blogofile.cache import (
@@ -13,6 +14,7 @@ from blogofile.cache import (
 )
 from . import commands
 
+_pkg_info = pkginfo.Installed('blogofile_blog')
 
 ## Configure the plugin meta information:
 __dist__ = dict(
@@ -22,17 +24,17 @@ __dist__ = dict(
     #referenced as bf.config.plugins.name
     config_name="blog",
     #Your name:
-    author="Ryan McGuire, Doug Latornell, and the Blogofile Contributors",
+    author=_pkg_info.author,
     #The version number:
-    version="0.8b1",
+    version=_pkg_info.version,
     #The URL for the plugin (where to download, documentation etc):
-    url="http://www.blogofile.com",
+    url=_pkg_info.home_page,
     #A one line description of your plugin presented to other Blogofile users:
     description="A simple blog engine",
     #PyPI description, could be the same, except this text
     #should mention the fact that this is a Blogofile plugin
     #because non-Blogofile users will see this text:
-    pypi_description="A simple blog engine plugin for Blogofile",
+    pypi_description=_pkg_info.description,
     #Command parser
     command_parser_setup=commands.setup_parser
     )

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import os.path
 import re
 import sys
 from setuptools import setup
-import blogofile_blog
 
+__version__ = "0.8b1"
 
 py_version = sys.version_info[:2]
 PY3 = py_version[0] == 3
@@ -18,7 +18,7 @@ else:
         raise RuntimeError(
             'On Python 2, Blogofile requires Python 2.6 or better')
 
-description = blogofile_blog.__dist__['pypi_description']
+description = "A simple blog engine plugin for Blogofile"
 with open('README.rst', 'rt') as readme:
     long_description = readme.read()
 with open('CHANGES.txt', 'rt') as changes:
@@ -27,6 +27,7 @@ with open('CHANGES.txt', 'rt') as changes:
 dependencies = [
     'Blogofile',
     'six',
+    'pkginfo',
     ]
 if PY26:
     dependencies.append('argparse')
@@ -57,12 +58,12 @@ classifiers.extend([
 
 setup(
     name="blogofile_blog",
-    version=blogofile_blog.__version__,
-    description=blogofile_blog.__dist__['pypi_description'],
+    version=__version__,
+    description=description,
     long_description=long_description,
-    author=blogofile_blog.__dist__["author"],
+    author="Ryan McGuire, Doug Latornell, and the Blogofile Contributors",
     author_email="blogofile-discuss@googlegroups.com",
-    url=blogofile_blog.__dist__["url"],
+    url="http://www.blogofile.com",
     license="MIT",
     classifiers=classifiers,
     packages=["blogofile_blog"],


### PR DESCRIPTION
This PR moves the package metadata out of the `blogofile_blog` module and into `setup.py`.  The motivation for this is to allow `python setup.py bdist_egg` to work without having Blogofile installed.

In turn this allows for blogofile_blog and blogofile to be installed in a single pip run (using a pip requirements file, say).  Also it make it possible to install blogofile_blog and blogofile using buildout without extreme pain.
