### PR TITLE
Fix ``blogofile blog posts list`` UnicodeEncodeError (in python 2)

### DIFF
--- a/blogofile_blog/commands.py
+++ b/blogofile_blog/commands.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import shutil
 import sys
 import os
+from six import u
 import blogofile.main
 
 
@@ -80,6 +81,6 @@ def list_posts(args):
     p_num = len(posts)
     for p in posts:
         print(
-            "{0:>4} | {1:%Y/%m/%d} | {2} | {3}"
+            u("{0:>4} | {1:%Y/%m/%d} | {2} | {3}")
             .format(p_num, p.date, p.title, p.filename))
         p_num -= 1

--- a/blogofile_blog/site_src/_controllers/blog/post.py
+++ b/blogofile_blog/site_src/_controllers/blog/post.py
@@ -107,7 +107,7 @@ class Post(object):
         self.__post_process()
 
     def __repr__(self):
-        return ("<Post title='{0.title}' date='{0.date:%Y/%m/%d %H:%M:%S}'>"
+        return ("<Post title={0.title!r} date='{0.date:%Y/%m/%d %H:%M:%S}'>"
                 .format(self))
 
     def __parse(self):

--- a/blogofile_blog/tests/integration/test_integration.py
+++ b/blogofile_blog/tests/integration/test_integration.py
@@ -3,11 +3,13 @@
 """
 import os
 import shutil
+import sys
 from tempfile import mkdtemp
 try:
     import unittest2 as unittest        # For Python 2.6
 except ImportError:
     import unittest                     # flake8 ignore # NOQA
+from six import StringIO
 from blogofile import main
 
 
@@ -41,3 +43,23 @@ class TestBlogofileBlogCommands(unittest.TestCase):
         self._call_entry_point(['blogofile', 'init', src_dir, 'blog'])
         self._call_entry_point(['blogofile', 'build', '-s', src_dir])
         self.assertIn('_site', os.listdir(src_dir))
+
+    def test_blogofile_list_blog_site_posts(self):
+        """`blogofile blog post list` works
+        """
+        self.addCleanup(os.chdir, os.getcwd())
+        src_dir = mkdtemp()
+        self.addCleanup(shutil.rmtree, src_dir)
+        os.rmdir(src_dir)
+        self._call_entry_point(['blogofile', 'init', src_dir, 'blog'])
+
+        save_cwd = os.getcwd()
+        save_stdout = sys.stdout
+        try:
+            os.chdir(src_dir)
+            sys.stdout = StringIO()
+            self._call_entry_point(['blogofile', 'blog', 'post', 'list'])
+            self.assertRegexpMatches(sys.stdout.getvalue(), r'Unicode Test')
+        finally:
+            sys.stdout = save_stdout
+            os.chdir(save_cwd)

--- a/blogofile_blog/tests/test_post.py
+++ b/blogofile_blog/tests/test_post.py
@@ -213,3 +213,13 @@ class TestPost(unittest.TestCase):
         expected = pytz.timezone(blog_config.timezone).localize(
             datetime(2012, 11, 11, 20, 58, 42))
         self.assertEqual(post.updated, expected)
+
+    def test_repr_with_unicode_title(self):
+        post_content = six.u(
+            '---\n'
+            'title: Gru\N{LATIN SMALL LETTER SHARP S}\n'
+            '---\n'
+            )
+        post = self._make_one(post_content)
+        post_repr = repr(post)
+        self.assertRegexpMatches(post_repr, r"title=u'Gru\\xdf'")


### PR DESCRIPTION
Under python 2 (2.6, in particular) the `blogofile blog post list` fails with a `UnicodeEncodeError` .  (This is with the stock blog site template.)

This fixes that, at least for me.  Also included is a test case which excercises the problem.

(I have tried not to break things for py3.2/3.3, but have not actually tested that.)
