### PR TITLE
Allow reStructuredText configuration from _config.py

### DIFF
--- a/blogofile_blog/site_src/_filters/rst_template.py
+++ b/blogofile_blog/site_src/_filters/rst_template.py
@@ -15,4 +15,5 @@ config = HC(
 
 
 def run(content):
-    return docutils.core.publish_parts(content, writer_name='html')['html_body']
+    return docutils.core.publish_parts(content, writer_name='html', settings_overrides={'syntax_highlight': 'short'})['html_body']
+


### PR DESCRIPTION
When writing posts with code snippets in rst format, e.g.:

```

---
title: Hello (Java) World

---

My first post, a sample Java program!

.. include::  ./snippets/HelloWorld.java
   :code: java
```

By default, docutils generates long pygment css class names [1], which are incompatible with the generated pygments css files [2], which use the short version.

This pull request demonstrates how to fix the concrete problem I'm having, but I think a generic approach to configure these settings from _config.py (blog.rst.syntax_highlight="short") would be a better solution.

So it's a pull request/pull request draft/feature suggestion - decide how do you want to handle it!

[1] http://docutils.sourceforge.net/docs/user/config.html#syntax-highlight
[2] http://pygments.org/docs/cmdline/#generating-styles
